### PR TITLE
Field formatter for service channels tags in search list

### DIFF
--- a/helfi_tpr.install
+++ b/helfi_tpr.install
@@ -741,3 +741,24 @@ function helfi_tpr_update_8041() : void {
     'source_row_status' => MigrateIdMapInterface::STATUS_NEEDS_UPDATE
   ])->execute();
 }
+
+/**
+ * Add has_unit field to Service entity.
+ */
+function helfi_tpr_update_8042() : void {
+  $fields['has_unit'] = BaseFieldDefinition::create('boolean')
+    ->setTranslatable(TRUE)
+    ->setRevisionable(FALSE)
+    ->setLabel(new TranslatableMarkup('Has Unit'))
+    ->setDescription(new TranslatableMarkup('If service have unit its true else false.'))
+    ->setDisplayOptions('form', [
+      'type' => 'readonly_field_widget',
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  foreach ($fields as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, 'tpr_service', 'helfi_tpr', $field);
+  }
+}

--- a/migrations/tpr_service.yml
+++ b/migrations/tpr_service.yml
@@ -26,6 +26,9 @@ process:
   errand_services:
     plugin: get
     source: exact_errand_services
+  has_unit:
+    plugin: tpr_empty_array
+    source: unit_ids
   links:
     plugin: sub_process
     source: links

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -161,6 +161,18 @@ class Service extends TprEntityBase {
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
+    $fields['has_unit'] = BaseFieldDefinition::create('boolean')
+      ->setTranslatable(FALSE)
+      ->setRevisionable(FALSE)
+      ->setLabel(new TranslatableMarkup('Has Unit'))
+      ->setDescription(new TranslatableMarkup('If service have unit its true else false.'))
+      ->setDisplayOptions('form', [
+        'type' => 'readonly_field_widget',
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
+
     $fields['service_id'] = BaseFieldDefinition::create('integer')
       ->setLabel(new TranslatableMarkup('Service grouping ID'))
       ->setDescription(new TranslatableMarkup('Value from service_id property'))
@@ -206,6 +218,7 @@ class Service extends TprEntityBase {
       ->setCardinality(BaseFieldDefinition::CARDINALITY_UNLIMITED)
       ->setDisplayConfigurable('view', TRUE)
       ->setDisplayConfigurable('form', TRUE);
+
     $fields['menu_link'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(new TranslatableMarkup('Menu link'))
       ->setSettings([

--- a/src/Fixture/Service.php
+++ b/src/Fixture/Service.php
@@ -57,11 +57,16 @@ final class Service extends FixtureBase {
               'url' => sprintf('https://localhost/2/%s/%s', $language, $id),
             ],
           ],
+          'unit_ids' => $id != 2 ? [] : [
+            1563,
+            1940,
+          ],
           'name_synonyms' =>  sprintf('Name synonyms %s %s', $language, $id),
           'service_id' => 10554
         ];
       }
     }
+
 
     $services[] = [
       'fi' => [

--- a/src/Plugin/Field/FieldFormatter/ErrandServicesFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/ErrandServicesFormatter.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\Field\FieldFormatter;
+
+use Drupal\Component\Utility\SortArray;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\helfi_tpr\Entity\ChannelTypeCollection;
+use Drupal\helfi_tpr\Entity\Service;
+
+/**
+ * Field formatter to render errand service maps.
+ *
+ * @FieldFormatter(
+ *   id = "tpr_service_err_channel_list",
+ *   label = @Translation("TPR - Errand Service Channels List"),
+ *   field_types = {
+ *     "entity_reference"
+ *   }
+ * )
+ */
+
+class ErrandServicesFormatter extends FormatterBase {
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+        'sort_order' => [],
+      ] + parent::defaultSettings();
+  }
+
+  /**
+   * Gets the channel types.
+   *
+   * @return \Drupal\helfi_tpr\Entity\ChannelTypeCollection
+   *   The channel type collection.
+   */
+  private function getChannelTypes() : ChannelTypeCollection {
+    return ChannelTypeCollection::createFromArray($this->getSetting('sort_order'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $form = parent::settingsForm($form, $form_state);
+
+    $form['sort_order'] = [
+      '#type' => 'table',
+      '#caption' => $this->t('Order'),
+      '#header' => [
+        $this->t('ID'),
+        $this->t('Label'),
+        $this->t('Weight'),
+      ],
+      '#tableselect' => FALSE,
+      '#tabledrag' => [
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => 'group-weight',
+        ],
+      ],
+    ];
+
+    foreach ($this->getChannelTypes() as $item) {
+      $form['sort_order'][$item->id] = [
+        '#attributes' => ['class' => ['draggable']],
+        '#weight' => $item->weight,
+        'id' => ['#plain_text' => $item->id],
+        'label' => ['#plain_text' => $item->label()],
+        'weight' => [
+          '#type' => 'weight',
+          '#title' => $this->t('Weight for @title', ['@title' => $item->label()]),
+          '#title_display' => 'invisible',
+          '#default_value' => $item->weight,
+          '#attributes' => ['class' => ['group-weight']],
+        ],
+      ];
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) : array {
+
+    if (!$items->getEntity() instanceof Service) {
+      throw new \InvalidArgumentException('The field can only be used with Services entities.');
+    }
+
+    $channelTypes = $this->getChannelTypes();
+
+    /** @var \Drupal\Core\Render\Renderer $renderer */
+    $renderer = \Drupal::service('renderer');
+
+    $channel_list = [];
+    $errand_services = $items->referencedEntities();
+    $item_list = [
+      '#theme' => 'item_list',
+      '#items' => [],
+    ];
+
+    foreach ($errand_services as $errand_service) {
+      /** @var \Drupal\helfi_tpr\Entity\ErrandService $errand_service */
+      foreach ($errand_service->getChannels() as $channel) {
+        if (isset($channel_list[$channel->getType()])) {
+          continue;
+        }
+
+        /** @var \Drupal\helfi_tpr\Entity\Channel $translatedChannel */
+        $translatedChannel = \Drupal::service('entity.repository')->getTranslationFromContext($channel, $langcode);
+        $channel_list[$channel->getType()] = [
+          '#name' => $translatedChannel->type_string->value,
+          '#weight' => $channelTypes[$channel->getType()]->weight,
+        ];
+        $renderer->addCacheableDependency($item_list, $translatedChannel);
+      }
+    }
+
+    /** @var \Drupal\helfi_tpr\Entity\Service $service */
+    $service = $items->getEntity();
+
+    if ($service->hasField('has_unit') && $service->has_unit->value) {
+      $channel_list['OFFICE'] = [
+        '#name' => $this->t('Office'),
+        '#weight' => 999,
+      ];
+    }
+
+    uasort($channel_list, [SortArray::class, 'sortByWeightProperty']);
+    $item_list['#items'] = array_column($channel_list, '#name');
+
+    $elements[0] = $item_list;
+
+    return $elements;
+  }
+
+}

--- a/src/Plugin/migrate/process/TprEmptyArray.php
+++ b/src/Plugin/migrate/process/TprEmptyArray.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tpr\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Check if empty return false else true.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "tpr_empty_array"
+ * )
+ *
+ * To return true or false use the following:
+ *
+ * @code
+ * field_text:
+ *   plugin: tpr_empty_array
+ *   source: array
+ * @endcode
+ *
+ */
+class TprEmptyArray extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    return !empty($value);
+  }
+}

--- a/tests/src/Kernel/ServiceMigrationTest.php
+++ b/tests/src/Kernel/ServiceMigrationTest.php
@@ -83,6 +83,14 @@ class ServiceMigrationTest extends MigrationTestBase {
         $this->assertEquals(sprintf('Name synonyms %s %s', $langcode, $translation->id()), $translation->get('name_synonyms')->value);
 
         $this->assertEquals(10554, $translation->get('service_id')->value);
+        $has_unit = !empty($translation->get('has_unit')->value);
+        if ($translation->id() == 2) {
+          $this->assertTrue($has_unit);
+        }
+        else {
+          $this->assertFalse($has_unit);
+        }
+
 
         foreach ([123, 456] as $key => $id) {
           $this->assertEquals($id, $translation->get('errand_services')->get($key)->target_id);


### PR DESCRIPTION
* created field formatter for errand services

* added unique channels

* added translated tags

* created migrate process for empty array + created has unit field

* modified the formatter for the errand service

* added the tags into list items theme

* added cache

* fixed pr comment

* removed unused var key

* added hasunit to tests + fixes on formatter

Co-authored-by: Arsene Claudiu Ion <arseneclaudiuion@192-168-0-179.rdsnet.ro>